### PR TITLE
feat: Add support for multi file generation from hbs templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ Default behaviour is to only include data structures / entities. If you want to 
 
 #### More
 
-There are more formatters and you can add additional ones specific to the language target you're building. See the CodeFormatter class. Each method in the codeformatter is available in the template without the $. 
-E.g. ```CodeFormatter::$returnType``` is available as
+There are more formatters and you can add additional ones specific to the language target you're building. See the CodeFormatter class. Each method in the codeformatter is available in the template without the `$`. E.g. `CodeFormatter::$returnType` is available as
 
 ```handlebars
 {{returnType data.value}}

--- a/src/CodeFormatter.ts
+++ b/src/CodeFormatter.ts
@@ -53,7 +53,7 @@ export class CodeFormatter {
     }
 
     $methods(values: string[]): string {
-        return values.join('\n\n');
+        return values.join('\n');
     }
 
     $type(value?: TypeLike): string {

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -158,12 +158,12 @@ export class Target {
 
         const processCurrentFile = () => {
             if (currentMode === 'skip') {
-                return null;
+                return;
             }
 
             // If file content is empty, skip it
             if (!currentFileContent.some((line) => line.trim())) {
-                return null;
+                return;
             }
 
             if (currentFileContent.length > 0) {

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -117,12 +117,14 @@ export function create(data: any, context: any, codeFormatter: CodeFormatter): T
 
     handlebarInstance.registerHelper('consumes', function (this: any, type, options: HelperOptions) {
         if (!context.spec.consumers) {
-            return '';
+            return options.inverse(this);
         }
 
         if (_.find(context.spec.consumers, findKindCaseInsensitive(type))) {
             return options.fn(this);
         }
+
+        return options.inverse(this);
     });
 
     handlebarInstance.registerHelper('provides', function (this: any, type, options: HelperOptions) {


### PR DESCRIPTION
Introducing support for multiple files being generated from a single template

If a template e.g. looks like this

```
{#each spec.methods}
//#FILENAME:src/mocks/handlers/{{base}}/{{name}}.ts:create-only
... mock code for {{name}}
{{/each}}
```

It could output multiple files

```
// src/mocks/handlers/messages/getMessages.ts
... mock code for getMessages
```

```
// src/mocks/handlers/messages/addMessage.ts
... mock code for addMessage
```

```
// src/mocks/handlers/messages/deleteMessage.ts
... mock code for deleteMessage
```

```
// src/mocks/handlers/messages/deleteAllMessages.ts
... mock code for deleteAllMessages
```
