### PR TITLE
fix: add raw helper to fix {{{{raw}}}} blocks

### DIFF
--- a/src/Template.ts
+++ b/src/Template.ts
@@ -153,6 +153,10 @@ export function create(contextOptions: any, data: any, context: any, codeFormatt
         );
     });
 
+    handlebarInstance.registerHelper('raw', function (this: any, options:HelperOptions) {
+        return options.fn(this);
+    });
+
     handlebarInstance.registerHelper('when', function (this: any, type, options) {
         const inner = options.fn(this);
         const [whenTrue, whenFalse] = inner.split(/\|\|/);


### PR DESCRIPTION
As seen on the handlebars playground, we need a method to call:
[playground](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%2F%2F%20quad%20braces%20%3D%20raw%20block%20-%20still%20needs%20a%20function%20to%20call%20though%5Cn%7B%7B%7B%7Braw%7D%7D%7D%7D%5Cn%20%20%20%20%20%20%20%20%3CBox%20sx%3D%7B%7B%20width%3A%20'100%25'%2C%20height%3A%20'100%25'%20%7D%7D%3E%5Cn%7B%7B%7B%7B%2Fraw%7D%7D%7D%7D%5Cn%2F%2F%20this%20is%20a%20regular%20function%20call%20-%20thus%20the%20escape%5Cn%7B%7B%23raw%7D%7D%5Cn%20%20%20%20%20%20%20%20%3CBox%20sx%3D%5C%5C%7B%7B%20width%3A%20'100%25'%2C%20height%3A%20'100%25'%20%7D%7D%3E%5Cn%7B%7B%2Fraw%7D%7D%5Cn%5Cn%2F%2F%20Calling%20an%20unknown%20method%20returns%20nothing%5Cn%7B%7B%7B%7Bderp%7D%7D%7D%7D%5Cntest%5Cn%7B%7B%7B%7B%2Fderp%7D%7D%7D%7D%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20firstname%3A%20%5C%22Yehuda%5C%22%2C%5Cn%20%20lastname%3A%20%5C%22Katz%5C%22%2C%5Cn%7D%5Cn%22%2C%22output%22%3A%22%2F%2F%20quad%20braces%20%3D%20raw%20block%20-%20still%20needs%20a%20function%20to%20call%20though%5Cn%20%20%20%20%20%20%20%20%3CBox%20sx%3D%7B%7B%20width%3A%20'100%25'%2C%20height%3A%20'100%25'%20%7D%7D%3E%5Cn%2F%2F%20this%20is%20a%20regular%20function%20call%20-%20thus%20the%20escape%5Cn%20%20%20%20%20%20%20%20%3CBox%20sx%3D%7B%7B%20width%3A%20'100%25'%2C%20height%3A%20'100%25'%20%7D%7D%3E%5Cn%5Cn%2F%2F%20Calling%20an%20unknown%20method%20returns%20nothing%5Cn%22%2C%22preparationScript%22%3A%22Handlebars.registerHelper('raw'%2C%20function%20(options)%20%7B%5Cn%20%20%20%20return%20options.fn()%5Cn%7D)%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.8%22%7D)